### PR TITLE
Make ProofOfWorkThreshold a uint64

### DIFF
--- a/network.go
+++ b/network.go
@@ -47,7 +47,7 @@ type Constants struct {
 	EndorsersPerBlock            int      `json:"endorsers_per_block"`
 	HardGasLimitPerOperation     *Int     `json:"hard_gas_limit_per_operation"`
 	HardGasLimitPerBlock         *Int     `json:"hard_gas_limit_per_block"`
-	ProofOfWorkThreshold         string   `json:"proof_of_work_threshold"`
+	ProofOfWorkThreshold         uint64   `json:"proof_of_work_threshold,string"`
 	TokensPerRoll                string   `json:"tokens_per_roll"`
 	MichelsonMaximumTypeSize     int      `json:"michelson_maximum_type_size"`
 	SeedNonceRevelationTip       string   `json:"seed_nonce_revelation_tip"`


### PR DESCRIPTION
JSONUnmarshal can handle converting this string'd value into a uint64. This way, client applications do not have to use strconv.ParseUint() to do the conversion.